### PR TITLE
Refactor/#61 retrospect flow structure

### DIFF
--- a/src/components/retro/RetrospectMainBlock.tsx
+++ b/src/components/retro/RetrospectMainBlock.tsx
@@ -4,7 +4,12 @@ import { EmotionChips } from '@/components/common/Emotionchips';
 import { MemoCard } from '@/components/common/MemoCard';
 import { WRITE_DATA } from '@/data/writeData';
 
-export const RetrospectMainBlock = ({ editable }: { editable: boolean }) => {
+type Props = {
+  editable: boolean;
+  hasPhotos?: boolean;
+};
+
+export const RetrospectMainBlock = ({ editable }: Props) => {
   return (
     <motion.div
       layoutId='retrospect-block'

--- a/src/pages/RetrospectFlowPage.tsx
+++ b/src/pages/RetrospectFlowPage.tsx
@@ -13,6 +13,9 @@ const RetrospectFlowPage = () => {
   // 임시 테스트용
   const tempResult: 'Signal' | 'Noise' = 'Signal';
 
+  const photos = WRITE_DATA.photos; // or 실제 상태/응답 데이터
+  const hasPhotos = photos.length > 0;
+
   const navigate = useNavigate();
 
   const handleBack = () => navigate(-1);

--- a/src/pages/RetrospectFlowPage.tsx
+++ b/src/pages/RetrospectFlowPage.tsx
@@ -4,9 +4,10 @@ import EmotionAnalysisList from '@/components/analysis/EmotionAnalysisList';
 import { LayoutGroup, motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { RetrospectMainBlock } from '@/components/retro/RetrospectMainBlock';
+import type { RetrospectStep } from '@/types/retrospect';
 
 const RetrospectFlowPage = () => {
-  const [step, setStep] = useState<'write' | 'confirm' | 'analysis'>('write');
+  const [step, setStep] = useState<RetrospectStep>('write');
   const [analysisResult, setAnalysisResult] = useState<'Signal' | 'Noise' | null>(null);
 
   // 임시 테스트용

--- a/src/types/retrospect.ts
+++ b/src/types/retrospect.ts
@@ -1,14 +1,9 @@
-export type PhotoItem = {
-  id: string;
-  url: string;
-  isPick: boolean;
-  file?: File;
-};
+export type RetrospectStep = 'write' | 'confirm' | 'analysis';
 
-export type RetrospectDraft = {
-  dateString: string;
-  photos: PhotoItem[];
-  emotion: string | null;
-  title: string;
-  content: string;
-};
+export type AnalysisResult = 'Signal' | 'Noise';
+
+export interface RetrospectUIState {
+  step: RetrospectStep;
+  editable: boolean;
+  hasPhotos: boolean;
+}


### PR DESCRIPTION
## 📂 관련 이슈

- closes #61 

---

## 🛠️ 작업 사항

- [ ] 회고 플로우(step) 상태 타입 공통화
- [ ] RetrospectFlowPage 상태 기반 구조 정리 (기능 변경 X
- [ ] 사진 유무 상태 값(hasPhotos) 준비
- [ ] RetrospectMainBlock props 타입 구조 정리

---

## 📸 관련 이미지 (스크린샷 또는 동영상)

---

## 💬 기타 설명

> 💡 사진 UI 분기 작업을 위한 구조 및 타입 리팩터링만 포함했습니다! 실제 사진 유무에 따른 UI 분기는 별도 이슈에서 진행할 생각입니다..!
